### PR TITLE
Upgrade Heroku stack: heroku-22 → heroku-24

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "lachstock",
   "scripts": {
   },
-  "stack": "heroku-22",
+  "stack": "heroku-24",
   "env": {
     "RACK_ENV": {
       "required": true


### PR DESCRIPTION
## Summary

- Updates `app.json` stack from `heroku-22` to `heroku-24` (Ubuntu 24.04)
- Stack already set on the Heroku app via `heroku stack:set heroku-24`

heroku-24 is the current default stack. Ruby 3.4.2 is fully supported.

## Verification

After deploying: `heroku info --app lachstock` should show `Stack: heroku-24`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)