### PR TITLE
Fix broken avatar URL — switch to Gravatar

### DIFF
--- a/views/_vcard.haml
+++ b/views/_vcard.haml
@@ -1,6 +1,6 @@
 %article#hcard-Lachlan-Hardy.vcard.package.pure-g-r
   .pure-u-1-3
-    %img.photo{:src => "https://pbs.twimg.com/profile_images/722138217529655296/9ceE1mjD.jpg", :height => "128", :alt => "Your host: Lachlan Hardy", :width => "128"}
+    %img.photo{:src => "https://www.gravatar.com/avatar/c21994a72009ac4d4278b5dc11617696?s=128", :height => "128", :alt => "Your host: Lachlan Hardy", :width => "128"}
   .pure-u-2-3
     %h2.title
       %a.url.fn{:href => "http://lachstock.com.au/", :rel => "me"} Lachlan Hardy


### PR DESCRIPTION
## Summary

- Replaces dead Twitter CDN URL with Gravatar derived from `lachlan@lachstock.com.au`
- Gravatar URL: `https://www.gravatar.com/avatar/c21994a72009ac4d4278b5dc11617696?s=128`

🤖 Generated with [Claude Code](https://claude.com/claude-code)