### PR TITLE
Modernise app structure and update contact info

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,25 +1,3 @@
-root_dir = File.dirname(__FILE__)
-
-# the middlewares
-require 'rack'
-
-# the app
-require 'sinatra'
 require './lachstock'
-
-# set :views => File.join(root_dir, 'views')
-
-set :haml, {:format => :html5, :escape_html => false}
-set :app_file => File.join(root_dir, 'lachstock.rb')
-set :run => false
-set :environment => ENV['RACK_ENV'] ? ENV["RACK_ENV"].to_sym : "development"
-# set :environment => 'production' # for testing minification etc
-set :raise_errors => true
-
-if ENV['RACK_ENV'] == 'development'
-  log = File.new("log/sinatra.log", "a")
-  STDOUT.reopen(log)
-  STDERR.reopen(log)
-end
 
 run Lachstock::App.new

--- a/lachstock.rb
+++ b/lachstock.rb
@@ -1,11 +1,6 @@
-require 'rubygems'
-require 'sinatra/base'
-require 'haml'
-# require 'twitter'
-require 'yaml'
+require "bundler"
+Bundler.require(:default)
 require 'cgi'
-require 'net/http'
-require 'pp' # only for dev work
 
 module Lachstock
   load "#{File.dirname(__FILE__)}/lib/metadata.rb"
@@ -15,8 +10,21 @@ module Lachstock
       require "#{File.dirname(__FILE__)}/#{helper}"
     end
 
+    configure do
+      set :haml, {:format => :html5, :escape_html => false}
+      set :raise_errors, true
+    end
+
     helpers do
       include Lachstock::Helpers
+
+      def development?
+        settings.development?
+      end
+
+      def production?
+        settings.production?
+      end
     end
 
     error do
@@ -27,7 +35,6 @@ module Lachstock
       handle_fail
     end
 
-    # homepage
     get '/' do
       @category = "home"
       haml :index
@@ -48,7 +55,6 @@ module Lachstock
       haml :feeds, {:format => :xhtml, :layout => false}
     end
 
-    # This is now obsolete, replace with mod_rewrite rule
     get '/feeds/:category' do
       @category = params[:category]
       @items = Metadata.type(@category.to_sym).all.sort_by {|item| item.published}.reverse
@@ -84,7 +90,7 @@ module Lachstock
     get '/*/files/:filename.:filetype' do
       filetype = params[:filetype] == "zip" ? "zip" : "#{params[:filetype]}.txt"
       file = "#{settings.views}/#{params[:splat]}/files/#{params[:filename]}.#{filetype}"
-      if File.exists? file
+      if File.exist? file
         content_type 'text/plain', :charset => 'utf-8'
         send_file(file)
       else

--- a/lib/helpers/comments.rb
+++ b/lib/helpers/comments.rb
@@ -1,3 +1,5 @@
+require "yaml"
+
 module Lachstock
   module Helpers
     def comment_builder

--- a/lib/helpers/static_files.rb
+++ b/lib/helpers/static_files.rb
@@ -1,13 +1,13 @@
 module Lachstock
   module Helpers
     def versioned_stylesheet(stylesheet)
-      directory = settings.environment == :production ? "stylesheets" : "stylesheets"
-      "/#{directory}/#{stylesheet}.css?" + File.mtime(File.join(Sinatra::Application.public_folder, "stylesheets", "#{stylesheet}.css")).to_i.to_s
+      "/stylesheets/#{stylesheet}.css?" + File.mtime(File.join(Sinatra::Application.public_folder, "stylesheets", "#{stylesheet}.css")).to_i.to_s
     end
+
     def versioned_javascript(js)
-      directory = settings.environment == :production ? "javascripts" : "javascripts"
-      "/#{directory}/#{js}.js?" + File.mtime(File.join(Sinatra::Application.public_folder, "javascripts", "#{js}.js")).to_i.to_s
+      "/javascripts/#{js}.js?" + File.mtime(File.join(Sinatra::Application.public_folder, "javascripts", "#{js}.js")).to_i.to_s
     end
+
     def versioned_favicon
       "/favicon.ico?" + File.mtime(File.join(Sinatra::Application.public_folder, "favicon.ico")).to_i.to_s
     end

--- a/views/_vcard.haml
+++ b/views/_vcard.haml
@@ -12,6 +12,3 @@
       %li
         AU Phone:
         %a.tel{:href => "tel:+61407091518"} +61407091518
-      %li
-        US Phone:
-        %a.tel{:href => "tel:+12064109027"} +12064109027

--- a/views/_vcard.haml
+++ b/views/_vcard.haml
@@ -4,7 +4,7 @@
   .pure-u-2-3
     %h2.title
       %a.url.fn{:href => "http://lachstock.com.au/", :rel => "me"} Lachlan Hardy
-    %p.adr.subtitle <span class="locality">Melbourne</span>, <span class="region">VIC</span>, <span class="country-name">Australia</span>.
+    %p.adr.subtitle <span class="locality">Mullumbimby</span>, <span class="region">NSW</span>, <span class="country-name">Australia</span>.
     %ul.list.plain
       %li
         Email:

--- a/views/_vcard.haml
+++ b/views/_vcard.haml
@@ -15,6 +15,3 @@
       %li
         US Phone:
         %a.tel{:href => "tel:+12064109027"} +12064109027
-      %li
-        Skype:
-        %a.skype{:href => "skype:lachlanhardy2"} lachlanhardy2


### PR DESCRIPTION
## Summary

Applies relevant changes from the old "begin again" branch (#7), updated to work with current main.

**Stage 1 — Code cleanup:**
- Use `Bundler.require` instead of individual gem requires
- Move Sinatra settings into a `configure` block in `lachstock.rb`
- Add `development?`/`production?` helpers
- Strip `config.ru` down to 3 lines
- Add explicit `require "yaml"` in comments helper
- Remove pointless prod/dev ternary in static_files helper

**Stage 2 — vcard cleanup:**
- Switch avatar from dead Twitter CDN URL to Gravatar
- Remove Skype entry
- Remove US phone entry
- Update location to Mullumbimby, NSW

🤖 Generated with [Claude Code](https://claude.com/claude-code)